### PR TITLE
Sort iternary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/*

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "code-snippets",
+  "version": "1.0.0",
+  "description": "Collection of random code snippets.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/electrachong/code-snippets.git"
+  },
+  "author": "Electra Chong",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/electrachong/code-snippets/issues"
+  },
+  "homepage": "https://github.com/electrachong/code-snippets#readme"
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Collection of random code snippets.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha"
   },
   "repository": {
     "type": "git",
@@ -15,5 +15,8 @@
   "bugs": {
     "url": "https://github.com/electrachong/code-snippets/issues"
   },
-  "homepage": "https://github.com/electrachong/code-snippets#readme"
+  "homepage": "https://github.com/electrachong/code-snippets#readme",
+  "devDependencies": {
+    "mocha": "^5.2.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Collection of random code snippets.",
   "main": "index.js",
   "scripts": {
-    "test": "mocha"
+    "test": "mocha",
+    "lint": "eslint snippets/*.js"
   },
   "repository": {
     "type": "git",
@@ -17,6 +18,15 @@
   },
   "homepage": "https://github.com/electrachong/code-snippets#readme",
   "devDependencies": {
+    "eslint": "^5.7.0",
+    "eslint-config-airbnb-base": "^13.1.0",
+    "eslint-plugin-import": "^2.14.0",
     "mocha": "^5.2.0"
+  },
+  "eslintConfig": {
+    "extends": "airbnb-base",
+    "rules": {
+      "no-underscore-dangle": 0
+    }
   }
 }

--- a/snippets/sort_iternary.js
+++ b/snippets/sort_iternary.js
@@ -11,9 +11,8 @@ Example inputs:
 
 TODO:
   - Don't need to use combined loop, have a loop for each direction
-  - Add tests
 */
-const { debug } = require('../util/util.js')
+const { debug } = require('../util/util')
 
 const START = Symbol('start')
 const END = Symbol('end')
@@ -86,7 +85,4 @@ function printResult(input) {
   process.stdout.write(`Result: ${output}\n\n`)
 }
 
-printResult([['LAX', 'SFO'], ['SFO', 'BEX'], ['BEX', 'SLO']])
-printResult([['LAX', 'SFO'], ['BEX', 'SLO'],  ['SFO', 'BEX']])
-printResult([[1,2], [2,3], [3,4]])
-printResult([[2,3], [1,2], [3,4]])
+module.exports = sortIternary

--- a/snippets/sort_iternary.js
+++ b/snippets/sort_iternary.js
@@ -10,12 +10,13 @@ Example inputs:
   [1,2], [2,3], [3,4]
 
 TODO:
-  - Don't need to use combined loop, have a loop for each direction
+  - More syntactic sugar
 */
-const { debug } = require('../util/util')
 
-const START = Symbol('start')
-const END = Symbol('end')
+const { printDebug } = require('../util/util');
+
+const START = Symbol('start');
+const END = Symbol('end');
 
 function getTripMappings(unsortedList) {
   const destinationByDeparture = {};
@@ -25,21 +26,21 @@ function getTripMappings(unsortedList) {
     destinationByDeparture[departure] = destination;
     departureByDestination[destination] = departure;
   })
-  debug('destinationByDeparture', destinationByDeparture)
-  debug('departureByDestination', departureByDestination)
+  printDebug('destinationByDeparture', destinationByDeparture);
+  printDebug('departureByDestination', departureByDestination);
   return [destinationByDeparture, departureByDestination];
 }
 
 // Find the item where the previous departure was the destination
 function findPreviousTrip(trip, departureByDestination) {
-  const [departure, destination] = trip
-  return [departureByDestination[departure], departure]
+  const [departure, destination] = trip;
+  return [departureByDestination[departure], departure];
 }
 
 // Find the item where the previous destination is the departure
 function findNextTrip(trip, destinationByDeparture) {
-  const [departure, destination] = trip
-  return [destination, destinationByDeparture[destination]]
+  const [departure, destination] = trip;
+  return [destination, destinationByDeparture[destination]];
 }
 
 function sortIternary(unsortedList) {
@@ -47,42 +48,43 @@ function sortIternary(unsortedList) {
   const sortedList = [];
   sortedList.push(unsortedList[0]);
 
-  let firstItem = sortedList[0];
-  let lastItem = sortedList[sortedList.length - 1]
-
-  // Check if we have found the terminal trip on either end, and if not,
-  // use the existing first or last item to find the next or previous trip
-  while (!(firstItem === START && lastItem === END)) {
-    debug('current sortedList', sortedList)
-    if (firstItem !== START) {
-      const previousTrip = findPreviousTrip(sortedList[0], departureByDestination)
-      debug('previousTrip', previousTrip)
-      if (previousTrip[0] === undefined) {
-        // add start marker to indicate we've found the beginning
-        sortedList.unshift(START)
-      } else {
-        sortedList.unshift(previousTrip)
-      }
+  // Find the previous trip of the first item in the array, add to the array
+  // and repeat until we have encountered the first trip.
+  for (let firstItem = sortedList[0]; firstItem !== START; firstItem = sortedList[0]) {
+    const previousTrip = findPreviousTrip(firstItem, departureByDestination);
+    printDebug('previousTrip', previousTrip);
+    if (previousTrip[0] === undefined) {
+      // add start marker to indicate we've found the beginning
+      sortedList.unshift(START);
     } else {
-      const nextTrip = findNextTrip(sortedList[sortedList.length - 1], destinationByDeparture)
-      debug('nextTrip', nextTrip)
-      if (nextTrip[1] === undefined) {
-        // add end marker to indicate we've found the end
-        sortedList.push(END)
-      } else {
-        sortedList.push(nextTrip)
-      }
+      sortedList.unshift(previousTrip);
     }
-    firstItem = sortedList[0];
-    lastItem = sortedList[sortedList.length - 1]
   }
-  return sortedList.slice(1, sortedList.length - 1)
+
+  // Find the next trip of the last item in the array, add to the array
+  // and repeat until we have encountered the last trip.
+  for (
+    let lastItem = sortedList[sortedList.length - 1];
+    lastItem !== END;
+    lastItem = sortedList[sortedList.length - 1]
+  ) {
+    const nextTrip = findNextTrip(lastItem, destinationByDeparture);
+    printDebug('nextTrip', nextTrip);
+    if (nextTrip[1] === undefined) {
+      // add end marker to indicate we've found the end
+      sortedList.push(END);
+    } else {
+      sortedList.push(nextTrip);
+    }
+  }
+
+  return sortedList.slice(1, sortedList.length - 1);
 }
 
 function printResult(input) {
-  process.stdout.write(`\nFor input ${input}:\n`)
-  const output = sortIternary(input)
-  process.stdout.write(`Result: ${output}\n\n`)
+  process.stdout.write(`\nFor input ${input}:\n`);
+  const output = sortIternary(input);
+  process.stdout.write(`Result: ${output}\n\n`);
 }
 
-module.exports = sortIternary
+module.exports = sortIternary;

--- a/snippets/sort_iternary.js
+++ b/snippets/sort_iternary.js
@@ -10,7 +10,8 @@ Example inputs:
   [1,2], [2,3], [3,4]
 
 TODO:
-  - Probably don't need to push markers to array
+  - Improve semantics
+  - Lint and js docs
 */
 
 const { printDebug } = require('../util/util');
@@ -65,12 +66,14 @@ function findNextTrip(trip, destinationByDeparture) {
 // Find the previous trip of the first item in the array, add to the array
 // and repeat until we have encountered the first trip.
 function sortListToStart(sortedList, departureByDestination) {
-  for (let firstItem = sortedList[0]; firstItem !== START; firstItem = sortedList[0]) {
+  let foundStart = false;
+  while (foundStart === false) {
+    const firstItem = sortedList[0];
     const previousTrip = findPreviousTrip(firstItem, departureByDestination);
+    printDebug('current sortedList', sortedList)
     printDebug('previousTrip', previousTrip);
     if (previousTrip.departure === undefined) {
-      // add start marker to indicate we've found the beginning
-      sortedList.unshift(START);
+      foundStart = true
     } else {
       sortedList.unshift(previousTrip.toArray());
     }
@@ -80,16 +83,14 @@ function sortListToStart(sortedList, departureByDestination) {
 // Find the next trip of the last item in the array, add to the array
 // and repeat until we have encountered the last trip.
 function sortListToEnd(sortedList, destinationByDeparture) {
-  for (
-    let lastItem = sortedList[sortedList.length - 1];
-    lastItem !== END;
-    lastItem = sortedList[sortedList.length - 1]
-  ) {
+  let foundEnd = false;
+  while (foundEnd === false) {
+    const lastItem = sortedList[sortedList.length - 1]
     const nextTrip = findNextTrip(lastItem, destinationByDeparture);
+    printDebug('current sortedList', sortedList)
     printDebug('nextTrip', nextTrip);
     if (nextTrip.destination === undefined) {
-      // add end marker to indicate we've found the end
-      sortedList.push(END);
+      foundEnd = true;
     } else {
       sortedList.push(nextTrip.toArray());
     }
@@ -104,7 +105,7 @@ function sortIternary(unsortedList) {
   sortListToStart(sortedList, departureByDestination);
   sortListToEnd(sortedList, destinationByDeparture);
 
-  return sortedList.slice(1, sortedList.length - 1);
+  return sortedList
 }
 
 function printResult(input) {

--- a/snippets/sort_iternary.js
+++ b/snippets/sort_iternary.js
@@ -8,9 +8,6 @@ Problem:
 Example inputs:
   [['LAX', 'SFO'], ['SFO', 'BEX'], ['BEX', 'SLO']]
   [1,2], [2,3], [3,4]
-
-TODO:
-  - lint
 */
 
 const { printDebug } = require('../util/util');
@@ -65,11 +62,11 @@ class Trip {
 function getTripMappings(unsortedList) {
   const destinationByDeparture = {};
   const departureByDestination = {};
-  unsortedList.forEach(trip => {
-    const [departure, destination] = trip
+  unsortedList.forEach((trip) => {
+    const [departure, destination] = trip;
     destinationByDeparture[departure] = destination;
     departureByDestination[destination] = departure;
-  })
+  });
   printDebug('destinationByDeparture', destinationByDeparture);
   printDebug('departureByDestination', departureByDestination);
   return [destinationByDeparture, departureByDestination];
@@ -83,7 +80,7 @@ function getTripMappings(unsortedList) {
  * @return {Trip|undefined} the previous trip or undefined if no previous trip
  */
 function findPreviousTrip(trip, departureByDestination) {
-  const [departure, destination] = trip;
+  const [departure, _] = trip; // eslint-disable-line no-unused-vars
   const previousDeparture = departureByDestination[departure];
   if (!previousDeparture) {
     return undefined;
@@ -99,7 +96,7 @@ function findPreviousTrip(trip, departureByDestination) {
  * @return {Trip|undefined} the next trip or undefined if no next trip
  */
 function findNextTrip(trip, destinationByDeparture) {
-  const [departure, destination] = trip;
+  const [_, destination] = trip; // eslint-disable-line no-unused-vars
   const nextDestination = destinationByDeparture[destination];
   if (!nextDestination) {
     return undefined;
@@ -120,10 +117,10 @@ function sortListToStart(sortedList, departureByDestination) {
   while (foundStart === false) {
     const firstItem = sortedList[0];
     const previousTrip = findPreviousTrip(firstItem, departureByDestination);
-    printDebug('current sortedList', sortedList)
+    printDebug('current sortedList', sortedList);
     printDebug('previousTrip', previousTrip);
     if (previousTrip === undefined) {
-      foundStart = true
+      foundStart = true;
     } else {
       sortedList.unshift(previousTrip.toArray());
     }
@@ -141,9 +138,9 @@ function sortListToStart(sortedList, departureByDestination) {
 function sortListToEnd(sortedList, destinationByDeparture) {
   let foundEnd = false;
   while (foundEnd === false) {
-    const lastItem = sortedList[sortedList.length - 1]
+    const lastItem = sortedList[sortedList.length - 1];
     const nextTrip = findNextTrip(lastItem, destinationByDeparture);
-    printDebug('current sortedList', sortedList)
+    printDebug('current sortedList', sortedList);
     printDebug('nextTrip', nextTrip);
     if (nextTrip === undefined) {
       foundEnd = true;
@@ -175,6 +172,7 @@ function sortIternary(unsortedList) {
  * @param {Array.<string[]>} input
  * @return {undefined} - but print the result of calling sortIternary()
  */
+// eslint-disable-next-line no-unused-vars
 function printResult(input) {
   process.stdout.write(`\nFor input ${input}:\n`);
   const output = sortIternary(input);

--- a/snippets/sort_iternary.js
+++ b/snippets/sort_iternary.js
@@ -10,31 +10,58 @@ Example inputs:
   [1,2], [2,3], [3,4]
 
 TODO:
-  - Improve semantics
-  - Lint and js docs
+  - lint
 */
 
 const { printDebug } = require('../util/util');
 
+/**
+ * Class representing a trip.
+ * May not be strictly necessary yet since we don't utilize the getters so far.
+ */
 class Trip {
+  /**
+   * Create a trip.
+   * @constructor
+   * @param {string} departure - Point of departure
+   * @param {string} destination - Arrival or destination
+   */
   constructor(departure, destination) {
     this._departure = departure;
     this._destination = destination;
   }
 
+  /**
+   * Get the departure.
+   * @return {string} The departure.
+   */
   get departure() {
     return this._departure;
   }
 
+  /**
+   * Get the destination.
+   * @return {string} The destination.
+   */
   get destination() {
     return this._destination;
   }
 
+  /**
+   * Convert a trip into an array of two items representing the trip.
+   * @return {string[]} [departure, destination]
+   */
   toArray() {
     return [this._departure, this._destination];
   }
 }
 
+/**
+ * Iterate over an unsorted array of trips and return mappings of
+ * destinations by departures and departures by destinations.
+ * @param {Array.<string[]>} unsortedList - unsorted array of trip arrays
+ * @return {object[]} [destinationByDeparture, departureByDestination]
+ */
 function getTripMappings(unsortedList) {
   const destinationByDeparture = {};
   const departureByDestination = {};
@@ -48,7 +75,13 @@ function getTripMappings(unsortedList) {
   return [destinationByDeparture, departureByDestination];
 }
 
-// Find the item where the previous departure was the destination
+/**
+ * Find the trip where the current trip's departure was the destination
+ * @param {string[]} trip - two-item array of strings representing a trip
+ * @param {object} departureByDestination - a mapping of destination keys to
+ *  departures
+ * @return {Trip|undefined} the previous trip or undefined if no previous trip
+ */
 function findPreviousTrip(trip, departureByDestination) {
   const [departure, destination] = trip;
   const previousDeparture = departureByDestination[departure];
@@ -58,7 +91,13 @@ function findPreviousTrip(trip, departureByDestination) {
   return new Trip(previousDeparture, departure);
 }
 
-// Find the item where the previous destination is the departure
+/**
+ * Find the trip where the current trip's destination is the departure
+ * @param {string[]} trip - two-item array of strings representing a trip
+ * @param {object} destinationByDeparture - a mapping of departure keys to
+ *  destinations
+ * @return {Trip|undefined} the next trip or undefined if no next trip
+ */
 function findNextTrip(trip, destinationByDeparture) {
   const [departure, destination] = trip;
   const nextDestination = destinationByDeparture[destination];
@@ -68,8 +107,14 @@ function findNextTrip(trip, destinationByDeparture) {
   return new Trip(destination, nextDestination);
 }
 
-// Find the previous trip of the first item in the array, add to the array
-// and repeat until we have encountered the first trip.
+/**
+ * Find the previous trip of the first item in the current array, add to the
+ * array and repeat until we have encountered the first trip.
+ * @param {Array.<string[]>} sortedList - array containing trips sorted in order
+ * @param {object} departureByDestination - a mapping of destination keys to
+ *  departures
+ * @return {undefined} - MUTATES sortedList by adding arrays representing trips
+ */
 function sortListToStart(sortedList, departureByDestination) {
   let foundStart = false;
   while (foundStart === false) {
@@ -85,8 +130,14 @@ function sortListToStart(sortedList, departureByDestination) {
   }
 }
 
-// Find the next trip of the last item in the array, add to the array
-// and repeat until we have encountered the last trip.
+/**
+ * Find the next trip of the last item in the current array, add to the
+ * array and repeat until we have encountered the last trip.
+ * @param {Array.<string[]>} sortedList - array containing trips sorted in order
+ * @param {object} destinationByDeparture - a mapping of departure keys to
+ *  destinations
+ * @return {undefined} - MUTATES sortedList by adding arrays representing trips
+ */
 function sortListToEnd(sortedList, destinationByDeparture) {
   let foundEnd = false;
   while (foundEnd === false) {
@@ -102,6 +153,12 @@ function sortListToEnd(sortedList, destinationByDeparture) {
   }
 }
 
+/**
+ * Given an array of string arrays representing trips which may be out of order,
+ * return an array of string arrays with the trips sorted in order.
+ * @param {Array.<string[]>} unsortedList - array containing unsorted trips
+ * @return {Array.<string[]>} sortedList - array containg sorted trips
+ */
 function sortIternary(unsortedList) {
   const [destinationByDeparture, departureByDestination] = getTripMappings(unsortedList);
   const sortedList = [];
@@ -110,9 +167,14 @@ function sortIternary(unsortedList) {
   sortListToStart(sortedList, departureByDestination);
   sortListToEnd(sortedList, destinationByDeparture);
 
-  return sortedList
+  return sortedList;
 }
 
+/**
+ * Print given input and result of calling sortIternary() on the input.
+ * @param {Array.<string[]>} input
+ * @return {undefined} - but print the result of calling sortIternary()
+ */
 function printResult(input) {
   process.stdout.write(`\nFor input ${input}:\n`);
   const output = sortIternary(input);

--- a/snippets/sort_iternary.js
+++ b/snippets/sort_iternary.js
@@ -16,9 +16,6 @@ TODO:
 
 const { printDebug } = require('../util/util');
 
-const START = Symbol('start');
-const END = Symbol('end');
-
 class Trip {
   constructor(departure, destination) {
     this._departure = departure;
@@ -54,13 +51,21 @@ function getTripMappings(unsortedList) {
 // Find the item where the previous departure was the destination
 function findPreviousTrip(trip, departureByDestination) {
   const [departure, destination] = trip;
-  return new Trip(departureByDestination[departure], departure);
+  const previousDeparture = departureByDestination[departure];
+  if (!previousDeparture) {
+    return undefined;
+  }
+  return new Trip(previousDeparture, departure);
 }
 
 // Find the item where the previous destination is the departure
 function findNextTrip(trip, destinationByDeparture) {
   const [departure, destination] = trip;
-  return new Trip(destination, destinationByDeparture[destination]);
+  const nextDestination = destinationByDeparture[destination];
+  if (!nextDestination) {
+    return undefined;
+  }
+  return new Trip(destination, nextDestination);
 }
 
 // Find the previous trip of the first item in the array, add to the array
@@ -72,7 +77,7 @@ function sortListToStart(sortedList, departureByDestination) {
     const previousTrip = findPreviousTrip(firstItem, departureByDestination);
     printDebug('current sortedList', sortedList)
     printDebug('previousTrip', previousTrip);
-    if (previousTrip.departure === undefined) {
+    if (previousTrip === undefined) {
       foundStart = true
     } else {
       sortedList.unshift(previousTrip.toArray());
@@ -89,7 +94,7 @@ function sortListToEnd(sortedList, destinationByDeparture) {
     const nextTrip = findNextTrip(lastItem, destinationByDeparture);
     printDebug('current sortedList', sortedList)
     printDebug('nextTrip', nextTrip);
-    if (nextTrip.destination === undefined) {
+    if (nextTrip === undefined) {
       foundEnd = true;
     } else {
       sortedList.push(nextTrip.toArray());

--- a/snippets/sort_iternary.js
+++ b/snippets/sort_iternary.js
@@ -10,13 +10,32 @@ Example inputs:
   [1,2], [2,3], [3,4]
 
 TODO:
-  - More syntactic sugar
+  - Probably don't need to push markers to array
 */
 
 const { printDebug } = require('../util/util');
 
 const START = Symbol('start');
 const END = Symbol('end');
+
+class Trip {
+  constructor(departure, destination) {
+    this._departure = departure;
+    this._destination = destination;
+  }
+
+  get departure() {
+    return this._departure;
+  }
+
+  get destination() {
+    return this._destination;
+  }
+
+  toArray() {
+    return [this._departure, this._destination];
+  }
+}
 
 function getTripMappings(unsortedList) {
   const destinationByDeparture = {};
@@ -34,35 +53,33 @@ function getTripMappings(unsortedList) {
 // Find the item where the previous departure was the destination
 function findPreviousTrip(trip, departureByDestination) {
   const [departure, destination] = trip;
-  return [departureByDestination[departure], departure];
+  return new Trip(departureByDestination[departure], departure);
 }
 
 // Find the item where the previous destination is the departure
 function findNextTrip(trip, destinationByDeparture) {
   const [departure, destination] = trip;
-  return [destination, destinationByDeparture[destination]];
+  return new Trip(destination, destinationByDeparture[destination]);
 }
 
-function sortIternary(unsortedList) {
-  const [destinationByDeparture, departureByDestination] = getTripMappings(unsortedList);
-  const sortedList = [];
-  sortedList.push(unsortedList[0]);
-
-  // Find the previous trip of the first item in the array, add to the array
-  // and repeat until we have encountered the first trip.
+// Find the previous trip of the first item in the array, add to the array
+// and repeat until we have encountered the first trip.
+function sortListToStart(sortedList, departureByDestination) {
   for (let firstItem = sortedList[0]; firstItem !== START; firstItem = sortedList[0]) {
     const previousTrip = findPreviousTrip(firstItem, departureByDestination);
     printDebug('previousTrip', previousTrip);
-    if (previousTrip[0] === undefined) {
+    if (previousTrip.departure === undefined) {
       // add start marker to indicate we've found the beginning
       sortedList.unshift(START);
     } else {
-      sortedList.unshift(previousTrip);
+      sortedList.unshift(previousTrip.toArray());
     }
   }
+}
 
-  // Find the next trip of the last item in the array, add to the array
-  // and repeat until we have encountered the last trip.
+// Find the next trip of the last item in the array, add to the array
+// and repeat until we have encountered the last trip.
+function sortListToEnd(sortedList, destinationByDeparture) {
   for (
     let lastItem = sortedList[sortedList.length - 1];
     lastItem !== END;
@@ -70,13 +87,22 @@ function sortIternary(unsortedList) {
   ) {
     const nextTrip = findNextTrip(lastItem, destinationByDeparture);
     printDebug('nextTrip', nextTrip);
-    if (nextTrip[1] === undefined) {
+    if (nextTrip.destination === undefined) {
       // add end marker to indicate we've found the end
       sortedList.push(END);
     } else {
-      sortedList.push(nextTrip);
+      sortedList.push(nextTrip.toArray());
     }
   }
+}
+
+function sortIternary(unsortedList) {
+  const [destinationByDeparture, departureByDestination] = getTripMappings(unsortedList);
+  const sortedList = [];
+  sortedList.push(unsortedList[0]);
+
+  sortListToStart(sortedList, departureByDestination);
+  sortListToEnd(sortedList, destinationByDeparture);
 
   return sortedList.slice(1, sortedList.length - 1);
 }

--- a/snippets/sort_iternary.js
+++ b/snippets/sort_iternary.js
@@ -1,0 +1,133 @@
+/* example inputs:
+[['LAX', 'SFO'], ['SFO', 'BEX'], ['BEX', 'SLO']]
+[1,2], [2,3], [3,4]
+*/
+
+function orderTrip(array) {
+  const destinationByDeparture = {}
+  const departureByDestination = {}
+  array.forEach(trip => {
+    const departure = trip[0]
+    const destination = trip[1]
+    destinationByDeparture[departure] = destination
+    departureByDestination[destination] = departure
+  })
+  // console.log('destinationByDeparture', destinationByDeparture)
+  // => destinationByDeparture { LAX: 'SFO', SFO: 'BEX', BEX: 'SLO' }
+  // console.log('departureByDestination', departureByDestination)
+  // => departureByDestination { SFO: 'LAX', BEX: 'SFO', SLO: 'BEX' }
+  const newArray = []
+  newArray.push(array[0]) // ['LAX', 'SFO']
+  const [previousTrip, nextTrip] = findNeighborsForFirstTrip(array[0], destinationByDeparture, departureByDestination)
+  if (previousTrip[0] === undefined) {
+    newArray.unshift('START') // add a marker to indicate we've found the beginning
+  } else {
+    newArray.unshift(previousTrip)
+  }
+  if (nextTrip[1] === undefined) {
+    newArray.push('END') // add a marker to indicate we've found the end
+  } else {
+    newArray.push(nextTrip)
+  }
+  // console.log('newArray', newArray) => newArray [ 'START', [ 'LAX', 'SFO' ], [ 'SFO', 'BEX' ] ]
+
+  /*
+  // __ NOW FOR THE NEXT ITERATION __
+  if (newArray[0] === 'START' && newArray[newArray.length - 1] === 'END') {
+    // we're finished, can exit out of loop
+  }
+  if (newArray[0] === 'START') {
+    // find next trip for last item in new array
+    const newLastTrip = findNextTrip(newArray[newArray.length - 1], destinationByDeparture)
+    newArray.push(newLastTrip)
+  } else {
+    // find the previous trip for the first item in the array
+    const newFirstTrip = findPreviousTrip(newArray[0], departureByDestination)
+    newArray.unshift(newFirstTrip)
+  }
+  // console.log('newArray', newArray) =>  [ 'START', [ 'LAX', 'SFO' ], [ 'SFO', 'BEX' ], [ 'BEX', 'SLO' ] ]
+  */
+
+  // __ REVISED INTO A LOOP __
+  while (!(newArray[0] === 'START' && newArray[newArray.length - 1] === 'END')) {
+    if (newArray[0] === 'START') {
+      // find next trip for last item in new array
+      const newLastTrip = findNextTrip(newArray[newArray.length - 1], destinationByDeparture)
+      if (newLastTrip[1] === undefined) {
+        newArray.push('END') // add a marker to indicate we've found the end
+      } else {
+        newArray.push(newLastTrip)
+      }
+    } else {
+      // find the previous trip for the first item in the array
+      const newFirstTrip = findPreviousTrip(newArray[0], departureByDestination)
+      if (newFirstTrip[0] === undefined) {
+        newArray.unshift('START') // add a marker to indicate we've found the beginning
+      } else {
+        newArray.unshift(newFirstTrip)
+      }
+    }
+  }
+  // console.log('newArray', newArray)
+  // => newArray [ 'START',
+  // [ 'LAX', 'SFO' ],
+  // [ 'SFO', 'BEX' ],
+  // [ 'BEX', 'SLO' ],
+  // 'END' ]
+  return newArray.slice(1, newArray.length - 1) // [ [ 'LAX', 'SFO' ], [ 'SFO', 'BEX' ], [ 'BEX', 'SLO' ] ]
+}
+
+function findPreviousTrip(trip, departureByDestination) {
+  // find the item where the previous departure was the destination
+  const departure = trip[0]
+  const destination = trip[1]
+  return [departureByDestination[departure], departure] // departure, destination
+}
+
+function findNextTrip(trip, destinationByDeparture) {
+  // find the item where the previous destination (SFO) is the departure
+  const departure = trip[0]
+  const destination = trip[1]
+  return [destination, destinationByDeparture[destination]]
+}
+
+function findNeighborsForFirstTrip(trip, destinationByDeparture, departureByDestination) {
+  const departure = trip[0]
+  const destination = trip[1]
+  // console.log('departure', departure) => LAX
+  // console.log('destination', destination) => SFO
+
+  // find the item where the previous destination (SFO) is the departure
+  // TODO: replace with findNextTrip
+  const nextTrip = [destination, destinationByDeparture[destination]]
+  // console.log('nextTrip', nextTrip) => nextTrip [ 'SFO', 'BEX' ]
+
+  // find the item where the previous departure (LAX) was the destination
+  // TODO: replace with findPreviousTrip
+  const previousTrip = [departureByDestination[departure], departure]
+  // console.log('previousTrip', previousTrip) => previousTrip [ undefined, 'LAX' ]
+
+  return [previousTrip, nextTrip]
+}
+
+console.log(orderTrip([['LAX', 'SFO'], ['SFO', 'BEX'], ['BEX', 'SLO']]))
+console.log(orderTrip([['LAX', 'SFO'], ['BEX', 'SLO'],  ['SFO', 'BEX']]))
+console.log(orderTrip([[1,2], [2,3], [3,4]]))
+console.log(orderTrip([[2,3], [1,2], [3,4]]))
+
+/* (leftover notes from drafting)
+// take the first pair from the hash and push it into the array
+
+const firstTrip = [firstDeparture, firstDestination]
+newArray.push(firstTrip) // [LAX, SFO] <-- departure, destination
+
+// if it doesn't exist, that was the last element
+if (nextTrip == undefined) {
+  // do nothing? may want to set a marker
+}
+// find the item where the previous departure (LAX) was the destination
+const previousTrip = destinationByDeparture[firstDeparture]
+
+// we can also figure out the starting and ending elements
+// by counting the number of times we see their members
+*/

--- a/test/sort_iternary.js
+++ b/test/sort_iternary.js
@@ -1,0 +1,25 @@
+const assert = require('assert')
+
+const sortIternary = require('../snippets/sort_iternary')
+
+describe('sortIternary', function() {
+  it('should return the same array if already sorted', function() {
+    const input = [['LAX', 'SFO'], ['SFO', 'BEX'], ['BEX', 'SLO']]
+    const result = sortIternary(input)
+    assert.deepStrictEqual(input, result);
+  });
+
+  it('should return sorted array if not sorted', function() {
+    const input = [['SFO', 'BEX'], ['LAX', 'SFO'], ['BEX', 'SLO']]
+    const expectedResult = [['LAX', 'SFO'], ['SFO', 'BEX'], ['BEX', 'SLO']]
+    const result = sortIternary(input)
+    assert.deepStrictEqual(result, expectedResult);
+  });
+
+  it('should also work for non-string values', function() {
+    const input = [[1, 2], [3, 4], [2, 3]]
+    const expectedResult = [[1, 2], [2, 3], [3, 4]]
+    const result = sortIternary(input)
+    assert.deepStrictEqual(result, expectedResult);
+  });
+});

--- a/util/util.js
+++ b/util/util.js
@@ -1,0 +1,12 @@
+const DEBUG = (process.env['DEBUG'] === 'true')
+
+function debug(msg, value) {
+  if (!DEBUG)
+    return;
+  console.log('========== DEBUG ==========');
+  console.log(`${msg}:`, value);
+}
+
+module.exports = {
+  debug,
+};

--- a/util/util.js
+++ b/util/util.js
@@ -1,6 +1,6 @@
 const DEBUG = (process.env['DEBUG'] === 'true')
 
-function debug(msg, value) {
+function printDebug(msg, value) {
   if (!DEBUG)
     return;
   console.log('========== DEBUG ==========');
@@ -8,5 +8,5 @@ function debug(msg, value) {
 }
 
 module.exports = {
-  debug,
+  printDebug,
 };


### PR DESCRIPTION
Possible tweaks / optimizations:
* Don't currently use `Trip` to access `departure` or `destination` (basically provide syntactic sugar) so could remove as it is unnecessary. 
* To avoid unshifting the array, could search for the first trip before constructing the sorted array, and start with the first trip.
  * Searching for the first trip would involve iterating through the list of departures to see if the departure exists as a key in `departuresByDestination` (i.e.: is it ever a destination?) -- if not, then it is the first trip. See: PR https://github.com/electrachong/code-snippets/pull/2
* Can make `find{Next|Previous}Trip` and `sortListTo{Start|End}` functions more generic by making them accept a direction, e.g. `forwards` or `backwards`, as a parameter since they share some logic. I felt it may be easier to read as it is, although more verbose.